### PR TITLE
Add opt-in auto-save of the startup impact report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New opt-in setting to automatically save the startup impact report to `StartupImpactData.xml` after every game startup, so external tools (such as the RimSort mod manager) can display each mod's startup load time without requiring a manual save from the startup impact window. ([#2])
+- Startup impact reports now record each mod's package ID alongside its name, allowing external tools to match report entries to mods reliably. ([#2])
+
 ## [0.11.0] - 2026-06-08
 
 ### Added
@@ -217,6 +222,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First implementation of the mod.
 
+[#2]: https://github.com/ilyvion/loading-progress/issues/2
 [Unreleased]: https://github.com/ilyvion/loading-progress/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/ilyvion/loading-progress/compare/v0.10.0..v0.11.0
 [0.10.0]: https://github.com/ilyvion/loading-progress/compare/v0.9.6..v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -222,7 +222,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First implementation of the mod.
 
-[#2]: https://github.com/ilyvion/loading-progress/issues/2
 [Unreleased]: https://github.com/ilyvion/loading-progress/compare/v0.11.0...HEAD
 [0.11.0]: https://github.com/ilyvion/loading-progress/compare/v0.10.0..v0.11.0
 [0.10.0]: https://github.com/ilyvion/loading-progress/compare/v0.9.6..v0.10.0
@@ -252,3 +251,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.1.2]: https://github.com/ilyvion/loading-progress/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/ilyvion/loading-progress/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/ilyvion/loading-progress/releases/tag/v0.1.0
+[#2]: https://github.com/ilyvion/loading-progress/issues/2

--- a/Common/Languages/English/Keyed/Settings.xml
+++ b/Common/Languages/English/Keyed/Settings.xml
@@ -20,6 +20,8 @@
     <LoadingProgress.ShowFasterGameLoadingEarlyModContentLoading.Tip>When enabled, and Faster Game Loading is active, the mod will show an additional loading indicator for mod content that is loaded early during the game startup process.</LoadingProgress.ShowFasterGameLoadingEarlyModContentLoading.Tip>
     <LoadingProgress.TrackStartupLoadingImpact>Track startup loading impact</LoadingProgress.TrackStartupLoadingImpact>
     <LoadingProgress.TrackStartupLoadingImpact.Tip>When enabled, the mod will track the impact of startup loading impact from mods and the base game allowing you to see a detailed breakdown of what is causing the biggest delays during the loading process.</LoadingProgress.TrackStartupLoadingImpact.Tip>
+    <LoadingProgress.AutoSaveStartupImpactReport> - Automatically save startup impact report</LoadingProgress.AutoSaveStartupImpactReport>
+    <LoadingProgress.AutoSaveStartupImpactReport.Tip>When enabled, the startup impact report is automatically saved to StartupImpactData.xml in your RimWorld save data folder after every game startup, without having to open the startup impact window and press Save.\n\nThis lets external tools, such as the RimSort mod manager, show each mod's startup load time.</LoadingProgress.AutoSaveStartupImpactReport.Tip>
     <LoadingProgress.ProgressBarColor>Progress bar color</LoadingProgress.ProgressBarColor>
     <LoadingProgress.ProgressBarColor.Tip>The color of the main progress bar in the loading progress window.</LoadingProgress.ProgressBarColor.Tip>
     <LoadingProgress.SmallBarColor>Progress bar sub-stage color</LoadingProgress.SmallBarColor>

--- a/Source/ilyvion.LoadingProgress/Settings.cs
+++ b/Source/ilyvion.LoadingProgress/Settings.cs
@@ -127,6 +127,13 @@ internal sealed class Settings : ModSettings
         set => _trackStartupLoadingImpact = value;
     }
 
+    private bool _autoSaveStartupImpactReport;
+    public bool AutoSaveStartupImpactReport
+    {
+        get => _autoSaveStartupImpactReport;
+        set => _autoSaveStartupImpactReport = value;
+    }
+
     private Color _progressBarColor = Widgets_Progressbar.BarColor;
     public Color ProgressBarColor
     {
@@ -190,6 +197,11 @@ internal sealed class Settings : ModSettings
             true
         );
         Scribe_Values.Look(ref _trackStartupLoadingImpact, "trackStartupLoadingImpact", false);
+        Scribe_Values.Look(
+            ref _autoSaveStartupImpactReport,
+            "autoSaveStartupImpactReport",
+            false
+        );
         Scribe_Values.Look(ref _progressBarColor, "progressBarColor", Widgets_Progressbar.BarColor);
         Scribe_Values.Look(ref _smallBarColor, "smallBarColor", Widgets_Progressbar.SmallBarColor);
     }
@@ -263,6 +275,15 @@ internal sealed class Settings : ModSettings
             ref _trackStartupLoadingImpact,
             "LoadingProgress.TrackStartupLoadingImpact.Tip".Translate()
         );
+
+        if (_trackStartupLoadingImpact)
+        {
+            listingStandard.CheckboxLabeled(
+                "LoadingProgress.AutoSaveStartupImpactReport".Translate(),
+                ref _autoSaveStartupImpactReport,
+                "LoadingProgress.AutoSaveStartupImpactReport.Tip".Translate()
+            );
+        }
 
         listingStandard.ColorPicker(
             "LoadingProgress.ProgressBarColor",

--- a/Source/ilyvion.LoadingProgress/StartupImpact/Dialog/DialogStartupImpact.cs
+++ b/Source/ilyvion.LoadingProgress/StartupImpact/Dialog/DialogStartupImpact.cs
@@ -368,7 +368,7 @@ internal sealed class DialogStartupImpact : Window
         {
             try
             {
-                SaveSessionData();
+                StartupImpactSessionStorage.Save(_sessionData);
                 StatusText = "LoadingProgress.StartupImpact.Saved".Translate();
             }
             catch (Exception ex)
@@ -381,7 +381,7 @@ internal sealed class DialogStartupImpact : Window
         {
             try
             {
-                var newSessionData = LoadSessionData();
+                var newSessionData = StartupImpactSessionStorage.Load();
                 if (newSessionData != null)
                 {
                     _sessionData = newSessionData;
@@ -438,31 +438,6 @@ internal sealed class DialogStartupImpact : Window
                 );
             }
         }
-    }
-
-    private const string SaveFileName = "StartupImpactData.xml";
-    private const string SaveLabel = "sessionData";
-
-    private static string SaveFilePath =>
-        Path.Combine(GenFilePaths.SaveDataFolderPath, GenText.SanitizeFilename(SaveFileName));
-
-    private void SaveSessionData()
-    {
-        Scribe.saver.InitSaving(SaveFilePath, "StartupImpactSession");
-        Scribe_Deep.Look(ref _sessionData, SaveLabel);
-        Scribe.saver.FinalizeSaving();
-    }
-
-    private static StartupImpactSessionData? LoadSessionData()
-    {
-        StartupImpactSessionData? sessionData = null;
-        if (File.Exists(SaveFilePath))
-        {
-            Scribe.loader.InitLoading(SaveFilePath);
-            Scribe_Deep.Look(ref sessionData, SaveLabel);
-            Scribe.loader.FinalizeLoading();
-        }
-        return sessionData;
     }
 
     [StaticConstructorOnStartup]

--- a/Source/ilyvion.LoadingProgress/StartupImpact/Dialog/StartupImpactSessionModData.cs
+++ b/Source/ilyvion.LoadingProgress/StartupImpact/Dialog/StartupImpactSessionModData.cs
@@ -4,6 +4,7 @@ internal sealed class StartupImpactSessionModData : IExposable
 {
 #pragma warning disable IDE0032 // Use auto property
     private string modName = "";
+    private string modPackageId = "";
 #pragma warning restore IDE0032 // Use auto property
     private Dictionary<string, float> metrics = [];
     private float totalImpact;
@@ -11,6 +12,7 @@ internal sealed class StartupImpactSessionModData : IExposable
     private float offThreadTotalImpact;
 
     public string ModName => modName;
+    public string ModPackageId => modPackageId;
     public IReadOnlyDictionary<string, float> Metrics => metrics.AsReadOnly();
     public float TotalImpact => totalImpact;
     public IReadOnlyDictionary<string, float> OffThreadMetrics => offThreadMetrics;
@@ -20,6 +22,7 @@ internal sealed class StartupImpactSessionModData : IExposable
         new()
         {
             modName = info.Mod.Name ?? string.Empty,
+            modPackageId = info.Mod.PackageIdPlayerFacing ?? string.Empty,
             metrics = new Dictionary<string, float>(info.Profiler.Metrics),
             totalImpact = info.Profiler.TotalImpact,
             offThreadMetrics = new Dictionary<string, float>(info.Profiler.OffThreadMetrics),
@@ -29,6 +32,7 @@ internal sealed class StartupImpactSessionModData : IExposable
     public void ExposeData()
     {
         Scribe_Values.Look(ref modName!, "modName");
+        Scribe_Values.Look(ref modPackageId!, "modPackageId");
         Scribe_Collections.Look(
             ref metrics,
             "metrics",

--- a/Source/ilyvion.LoadingProgress/StartupImpact/Dialog/StartupImpactSessionStorage.cs
+++ b/Source/ilyvion.LoadingProgress/StartupImpact/Dialog/StartupImpactSessionStorage.cs
@@ -1,0 +1,29 @@
+namespace ilyvion.LoadingProgress.StartupImpact.Dialog;
+
+internal static class StartupImpactSessionStorage
+{
+    private const string SaveFileName = "StartupImpactData.xml";
+    private const string SaveLabel = "sessionData";
+
+    internal static string SaveFilePath =>
+        Path.Combine(GenFilePaths.SaveDataFolderPath, GenText.SanitizeFilename(SaveFileName));
+
+    internal static void Save(StartupImpactSessionData sessionData)
+    {
+        Scribe.saver.InitSaving(SaveFilePath, "StartupImpactSession");
+        Scribe_Deep.Look(ref sessionData, SaveLabel);
+        Scribe.saver.FinalizeSaving();
+    }
+
+    internal static StartupImpactSessionData? Load()
+    {
+        StartupImpactSessionData? sessionData = null;
+        if (File.Exists(SaveFilePath))
+        {
+            Scribe.loader.InitLoading(SaveFilePath);
+            Scribe_Deep.Look(ref sessionData, SaveLabel);
+            Scribe.loader.FinalizeLoading();
+        }
+        return sessionData;
+    }
+}

--- a/Source/ilyvion.LoadingProgress/StartupImpact/StartupImpact.cs
+++ b/Source/ilyvion.LoadingProgress/StartupImpact/StartupImpact.cs
@@ -40,6 +40,30 @@ internal sealed class StartupImpact
                 Assembly.GetExecutingAssembly(),
                 "StartupImpact"
             );
+
+            if (
+                LoadingProgressMod.Settings.TrackStartupLoadingImpact
+                && LoadingProgressMod.Settings.AutoSaveStartupImpactReport
+            )
+            {
+                // FinishLoading can run off the main thread, and Scribe.saver is
+                // global state also used from the main thread; defer the save.
+                LongEventHandler.ExecuteWhenFinished(static () =>
+                {
+                    try
+                    {
+                        Dialog.StartupImpactSessionStorage.Save(
+                            Dialog.StartupImpactSessionData.FromCurrentSession()
+                        );
+                    }
+                    catch (Exception e)
+                    {
+                        LoadingProgressMod.Error(
+                            "Failed to auto-save startup impact report: " + e
+                        );
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
Closes #2

## What

Adds a new opt-in setting, **" - Automatically save startup impact report"**, shown indented under "Track startup loading impact" (and only when it is enabled). When both are on, the startup impact report is saved to `StartupImpactData.xml` in the save data folder automatically after startup finishes — the same file, format, and location the dialog's Save button uses — so external tools can read it without the user having to open the startup impact window each run.

Report entries now also record each mod's package ID (`modPackageId`, from `ModContentPack.PackageIdPlayerFacing`), letting external tools match entries to mods reliably instead of by display name. Older reports without the element still load fine, since Scribe just leaves the field at its default.

## Why

This enables the mod-manager integration discussed in #2: RimSort has a feature branch ([RimSort/RimSort#2294](https://github.com/RimSort/RimSort/pull/2294)) that reads `StartupImpactData.xml` and shows each mod's startup load time in its mod lists, matching by `modPackageId` when present and falling back to the mod name. Without auto-save, the data goes stale unless the user remembers to save manually every startup.

## How

- `StartupImpact.FinishLoading()` queues the save via `LongEventHandler.ExecuteWhenFinished`, since `FinishLoading` can run off the main thread and `Scribe.saver` is global state also used from the main thread. The save is wrapped in try/catch and only logs on failure, so it can never break game loading.
- The dialog's private save/load members are extracted into a new `StartupImpactSessionStorage` class shared by the dialog and the auto-save path; the dialog's behavior is unchanged.
- New setting + English translation keys + changelog entry under Unreleased.

Defaults keep current behavior: both the new setting and tracking itself default to off.

## Testing

Built against 1.6 (`dotnet build`, 0 errors) and verified in-game with a ~220-mod list: with both settings enabled, `StartupImpactData.xml` is written automatically after startup with `modPackageId` populated for every entry, and RimSort picks it up on refresh. Manual Save/Load from the dialog still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)