### PR TITLE
Fixes two potential startup crashes (`NullReferenceException` and `DirectoryNotFoundException`) and a C# compilation failure in `LoadingProgressWindow.StageData`.

### DIFF
--- a/Source/ilyvion.LoadingProgress/CurrentMod_Patches.cs
+++ b/Source/ilyvion.LoadingProgress/CurrentMod_Patches.cs
@@ -27,7 +27,8 @@ internal static class LoadedModManager_LoadingDataTracker_Patches
             return;
         }
 
-        var total = xmls.SelectMany(x => x.xmlDoc.DocumentElement.ChildNodes.Cast<XmlNode>())
+        var total = xmls.Where(x => x?.xmlDoc?.DocumentElement != null)
+            .SelectMany(x => x.xmlDoc.DocumentElement.ChildNodes.Cast<XmlNode>())
             .Count();
         LoadingProgressWindow.StageProgress = (0, total);
     }

--- a/Source/ilyvion.LoadingProgress/LoadingProgressWindow.StageData.cs
+++ b/Source/ilyvion.LoadingProgress/LoadingProgressWindow.StageData.cs
@@ -777,7 +777,13 @@ internal sealed partial class LoadingProgressWindow
                         if (removeCount > 0)
                         {
                             // Remove only those rules
-                            StageRules.RemoveAll((r, idx) => idx < i && r.Stage != matchedStage);
+                            for (var j = i - 1; j >= 0; j--)
+                            {
+                                if (StageRules[j].Stage != matchedStage)
+                                {
+                                    StageRules.RemoveAt(j);
+                                }
+                            }
                         }
                     }
                     CurrentStageRule = rule;

--- a/Source/ilyvion.LoadingProgress/Translations.cs
+++ b/Source/ilyvion.LoadingProgress/Translations.cs
@@ -94,6 +94,10 @@ internal static class Translations
         string languageDirectory
     )
     {
+        if (!Directory.Exists(languageDirectory))
+        {
+            return;
+        }
         foreach (var file in Directory.GetFiles(languageDirectory, "*.xml"))
         {
             try


### PR DESCRIPTION
1. **Fix `NullReferenceException` in XML Combining (`CurrentMod_Patches.cs`)**
   - Filtered out `LoadableXmlAsset` instances with null `xmlDoc` or `DocumentElement` prior to counting child nodes in `CombineIntoUnifiedXMLPrefix`.
   - Prevents startup crashes when mods contain empty or malformed XML files.

2. **Fix Invalid `RemoveAll` Predicate (`LoadingProgressWindow.StageData.cs`)**
   - Replaced `StageRules.RemoveAll((r, idx) => ...)` with a backward `RemoveAt` loop.
   - Resolves a C# compilation error (CS1593) caused by passing a 2-parameter lambda to `List<T>.RemoveAll(Predicate<T>)` and correctly prunes obsolete stage rules.

3. **Fix `DirectoryNotFoundException` in Translation Loader (`Translations.cs`)**
   - Added `Directory.Exists` check before calling `Directory.GetFiles` in `LoadLanguage`.
   - Prevents unhandled exceptions if the expected language folder path does not exist on disk.